### PR TITLE
Adding tables to .script/tests/KqlvalidationsTests/CustomTables

### DIFF
--- a/.script/tests/KqlvalidationsTests/CustomTables/SophosEPAlerts_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SophosEPAlerts_CL.json
@@ -1,0 +1,73 @@
+{
+    "name": "SophosEPAlerts_CL",
+    "properties": [
+        {
+            "name": "TimeGenerated",
+            "type": "Datetime"
+        },
+        {
+            "name": "CustomerId",
+            "type": "string"
+        },
+        {
+            "name": "EventSeverity",
+            "type": "string"
+        },
+        {
+            "name": "EventVendor",
+            "type": "string"
+        },
+        {
+            "name": "EventType",
+            "type": "string"
+        },
+        {
+            "name": "EventProduct",
+            "type": "string"
+        },
+        {
+            "name": "event_service_event_id",
+            "type": "string"
+        },
+        {
+            "name": "EventEndTime",
+            "type": "datetime"
+        },
+        {
+            "name": "DvcAction",
+            "type": "string"
+        },
+        {
+            "name": "description",
+            "type": "string"
+        },
+        {
+            "name": "DvcHostname",
+            "type": "string"
+        },
+        {
+            "name": "EventOriginalUid",
+            "type": "string"
+        },
+        {
+            "name": "data",
+            "type": "dynamic"
+        },
+        {
+            "name": "Source",
+            "type": "string"
+        },
+        {
+            "name": "info",
+            "type": "dynamic"
+        },
+        {
+            "name": "ThreatName",
+            "type": "string"
+        },
+        {
+            "name": "threat_cleanable",
+            "type": "boolean"
+        }
+    ]
+}

--- a/.script/tests/KqlvalidationsTests/CustomTables/SophosEPEvents_CL.json
+++ b/.script/tests/KqlvalidationsTests/CustomTables/SophosEPEvents_CL.json
@@ -1,0 +1,121 @@
+{
+    "name": "SophosEPEvents_CL",
+    "properties": [
+        {
+            "name": "TimeGenerated",
+            "type": "Datetime"
+        },
+        {
+            "name": "EventVendor",
+            "type": "string"
+        },
+        {
+            "name": "EventProduct",
+            "type": "string"
+        },
+        {
+            "name": "EventType",
+            "type": "string"
+        },
+        {
+            "name": "amsi_threat_data",
+            "type": "dynamic"
+        },
+        {
+            "name": "appCerts",
+            "type": "dynamic"
+        },
+        {
+            "name": "AppSha256",
+            "type": "string"
+        },
+        {
+            "name": "CoreRemedyItems",
+            "type": "string"
+        },
+        {
+            "name": "CoreRemedyTotalItems",
+            "type": "int"
+        },
+        {
+            "name": "Created",
+            "type": "datetime"
+        },
+        {
+            "name": "CustomerId",
+            "type": "string"
+        },
+        {
+            "name": "details",
+            "type": "dynamic"
+        },
+        {
+            "name": "EndpointId",
+            "type": "string"
+        },
+        {
+            "name": "SrcDvcType",
+            "type": "string"
+        },
+        {
+            "name": "ThreatCategory",
+            "type": "string"
+        },
+        {
+            "name": "EventOriginalUid",
+            "type": "string"
+        },
+        {
+            "name": "ips_threat_data",
+            "type": "dynamic"
+        },
+        {
+            "name": "DvcHostname",
+            "type": "string"
+        },
+        {
+            "name": "EventMessage",
+            "type": "string"
+        },
+        {
+            "name": "EventSubType",
+            "type": "string"
+        },
+        {
+            "name": "EventSeverity",
+            "type": "string"
+        },
+        {
+            "name": "Source",
+            "type": "string"
+        },
+        {
+            "name": "source_info",
+            "type": "dynamic"
+        },
+        {
+            "name": "SrcIpAddr",
+            "type": "string"
+        },
+        {
+            "name": "ThreatName",
+            "type": "string"
+        },
+        {
+            "name": "DvcAction",
+            "type": "string"
+        },
+        {
+            "name": "DstUserSid",
+            "type": "string"
+        },
+        {
+            "name": "EventEndTime",
+            "type": "datetime"
+        },
+        {
+            "name": "whitelist_properties",
+            "type": "dynamic"
+        }
+    ]
+}


### PR DESCRIPTION
   Required items, please complete
   
   Change(s):
   - Adding 2 custom tables to the tests folder to complement the new sophos endpoint codeless connector

   Reason for Change(s):
   - v-prasadboke asked for it
   
   Version Updated:
NA

   Testing Completed:
NA

   Checked that the validations are passing and have addressed any issues that are present:
Na
